### PR TITLE
Added procedures to process masked array input in QGField

### DIFF
--- a/hn2016_falwa/oopinterface.py
+++ b/hn2016_falwa/oopinterface.py
@@ -1,4 +1,5 @@
 import numpy as np
+import warnings
 from scipy.interpolate import interp1d
 
 from hn2016_falwa import utilities
@@ -79,6 +80,31 @@ class QGField(object):
         This only initialize the attributes of the object. Analysis and
         computation are done by calling various methods.
         """
+
+        # === Check whether the input field is masked array. If so, turn them to normal array ===
+        if np.ma.is_masked(ylat):
+            warnings.warn(
+                'ylat is a masked array of dimension {dim} with {num} masked elements and fill value {fill}. '
+                .format(dim=ylat.shape, num=ylat.mask.sum(), fill=ylat.fill_value))
+            ylat = ylat.data
+
+        if np.ma.is_masked(u_field):
+            warnings.warn(
+                'u_field is a masked array of dimension {dim} with {num} masked elements and fill value {fill}. '
+                .format(dim=u_field.shape, num=u_field.mask.sum(), fill=u_field.fill_value))
+            u_field = u_field.data
+
+        if np.ma.is_masked(v_field):
+            warnings.warn(
+                'v_field is a masked array of dimension {dim} with {num} masked elements and fill value {fill}. '
+                .format(dim=v_field.shape, num=v_field.mask.sum(), fill=v_field.fill_value))
+            v_field = v_field.data
+
+        if np.ma.is_masked(t_field):
+            warnings.warn(
+                't_field is a masked array of dimension {dim} with {num} masked elements and fill value {fill}. '
+                .format(dim=t_field.shape, num=t_field.mask.sum(), fill=t_field.fill_value))
+            t_field = t_field.data
 
         # === Check if ylat is in ascending order and include the equator ===
         self._check_and_flip_ylat(ylat)
@@ -753,7 +779,7 @@ class QGField(object):
     @property
     def ptref(self):
         """
-        Reference state of potential temperature (\Theta_ref).
+        Reference state of potential temperature (\\Theta_ref).
         """
         if self._ptref is None:
             raise ValueError('ptref field is not computed yet.')

--- a/tests/test_oopinterface.py
+++ b/tests/test_oopinterface.py
@@ -1,8 +1,8 @@
 import os
 import pytest
+import warnings
 import numpy as np
 from math import pi
-from collections import namedtuple
 from scipy.interpolate import interp1d
 
 from hn2016_falwa.constant import *
@@ -25,27 +25,29 @@ theta_field = t_field * (plev[:, np.newaxis, np.newaxis] / P0) ** (-DRY_GAS_CONS
 
 def test_qgfield():
 
-    # Create a QGField object for testing
-    qgfield = QGField(
-        xlon=xlon,
-        ylat=ylat,
-        plev=plev,
-        u_field=u_field,
-        v_field=v_field,
-        t_field=t_field,
-        kmax=kmax,
-        maxit=100000,
-        dz=1000.,
-        prefactor=6500.,
-        npart=None,
-        tol=1.e-5,
-        rjac=0.95,
-        scale_height=SCALE_HEIGHT,
-        cp=CP,
-        dry_gas_constant=DRY_GAS_CONSTANT,
-        omega=EARTH_OMEGA,
-        planet_radius=EARTH_RADIUS
-    )
+    # Create a QGField object out of some masked array for testing. The test below is to ensure
+    # warning is raised for masked array.
+    with pytest.warns(UserWarning):
+        qgfield = QGField(
+            xlon=xlon,
+            ylat=np.ma.masked_equal(ylat, 0.0),
+            plev=plev,
+            u_field=np.ma.masked_equal(u_field, 0.0),
+            v_field=np.ma.masked_equal(v_field, 0.0),
+            t_field=np.ma.masked_equal(t_field, 0.0),
+            kmax=kmax,
+            maxit=100000,
+            dz=1000.,
+            prefactor=6500.,
+            npart=None,
+            tol=1.e-5,
+            rjac=0.95,
+            scale_height=SCALE_HEIGHT,
+            cp=CP,
+            dry_gas_constant=DRY_GAS_CONSTANT,
+            omega=EARTH_OMEGA,
+            planet_radius=EARTH_RADIUS
+        )
 
     # Check that the input fields are interpolated onto a grid of correct dimension
     # and the interpolated values are bounded.


### PR DESCRIPTION
A warning is raised if either `ylat`, `u_field`, `v_field` or `t_field` input is a masked array. Conversion of masked array to unmasked array takes place in `__init__` method of `QGField` such that there is no error when the input(s) is a masked array.

Closes #27 