### PR TITLE
Speed up LWA and flux computations

### DIFF
--- a/hn2016_falwa/compute_lwa_and_barotropic_fluxes.f90
+++ b/hn2016_falwa/compute_lwa_and_barotropic_fluxes.f90
@@ -3,37 +3,45 @@ SUBROUTINE compute_lwa_and_barotropic_fluxes(nlon, nlat, kmax, jd, &
                          a, om, dz, h, r, cp, prefactor, &
                          astar,astarbaro,ua1baro,ubaro,ua2baro,ep1baro,ep2baro,ep3baro,ep4)
 
+    implicit none
+
     integer, intent(in) :: nlon, nlat, kmax, jd
     real, intent(in) :: pv(nlon,nlat,kmax),uu(nlon,nlat,kmax),vv(nlon,nlat,kmax), &
                         pt(nlon,nlat,kmax),qref(jd,kmax),uref(jd,kmax),tref(jd,kmax)
-    real, intent(in) ::  a, om, dz, h, r
+    real, intent(in) ::  a, om, dz, h, r, cp, prefactor
     real, intent(out) :: astar(nlon,jd,kmax),astarbaro(nlon,jd),ua1baro(nlon,jd),ubaro(nlon,jd),&
                          ua2baro(nlon,jd),ep1baro(nlon,jd),ep2baro(nlon,jd),ep3baro(nlon,jd),ep4(nlon,jd)
     ! === dummy variables ===
+    integer :: i, j, jj, k
     real :: qe(nlon,nlat),ue(nlon,nlat)
     real :: ua1(nlon,jd,kmax)
     real :: ua2(nlon,jd,kmax),ep1(nlon,jd,kmax)
     real :: ep2(nlon,jd,kmax),ep3(nlon,jd,kmax)
     real :: tg(kmax)
-    real :: rkappa, zero, half, qtr, one
+    real :: aa, cor, dc, ep11, ep41, ep42, ep43, wt, zk, zz, dp, rkappa
+    real :: cosphi(0:jd+1), sinphi(0:jd+1)
+    real, parameter :: pi = acos(-1.)
 
-    pi = acos(-1.)
     dp = pi/float(nlat-1)
-    zero = 0.
-    half = 0.5
-    qtr = 0.25
-    one = 1.
     rkappa = r/cp
 
+    ! cos and sin of latitude are often used in the following computations.
+    ! Because the evaluation of trigonometric functions is computationally
+    ! expensive, values are computed once here and stored for later.
+    cosphi(0) = cos(0.) ! fill values for meridional
+    sinphi(0) = sin(0.) !  heat flux computation
+    do j=1,jd+1
+        cosphi(j) = cos(dp*float(j-1))
+        sinphi(j) = sin(dp*float(j-1))
+    enddo
 
     ! **** hemispheric-mean potential temperature ****
 
     tg(:) = 0.              ! mean PT
     wt = 0.                 ! area weight
     do j = 1,jd             ! NH
-        phi0 = dp*float(j-1)               ! latitude
-        tg(:) = tg(:)+cos(phi0)*tref(j,:)
-        wt = wt + cos(phi0)
+        tg(:) = tg(:)+cosphi(j)*tref(j,:)
+        wt = wt + cosphi(j)
     enddo
     tg(:) = tg(:)/wt       ! averaging
 
@@ -44,20 +52,25 @@ SUBROUTINE compute_lwa_and_barotropic_fluxes(nlon, nlat, kmax, jd, &
             do j = 1,jd-1            ! 13.5N and higher latitude
                 astar(i,j,k) = 0.       ! LWA*cos(phi)
                 ua2(i,j,k) = 0.         ! F2
-                phi0 = dp*float(j-1)           !latitude
-                cor = 2.*om*sin(phi0)          !Coriolis parameter
-                do jj = 1,jd
-                    phi1 = dp*float(jj-1)
+                cor = 2.*om*sinphi(j)          !Coriolis parameter
+                ! South of the current latitude
+                do jj = 1,j-1
                     qe(i,jj) = pv(i,jj+jd-1,k)-qref(j,k)*cor   !qe; Q = qref*cor
                     ue(i,jj) = uu(i,jj+jd-1,k)-uref(j,k)       !ue
-                    aa = a*dp*cos(phi1)                      !length element
-                    if((qe(i,jj).le.0.).and.(jj.ge.j)) then  !LWA*cos and F2
-                        astar(i,j,k)=astar(i,j,k)-qe(i,jj)*aa
-                        ua2(i,j,k) = ua2(i,j,k)-qe(i,jj)*ue(i,jj)*aa
-                    endif  
-                    if((qe(i,jj).gt.0.).and.(jj.lt.j)) then
+                    aa = a*dp*cosphi(jj)                       !length element
+                    if(qe(i,jj).gt.0.) then                    !LWA*cos(phi) and F2
                         astar(i,j,k)=astar(i,j,k)+qe(i,jj)*aa
                         ua2(i,j,k) = ua2(i,j,k)+qe(i,jj)*ue(i,jj)*aa
+                    endif  
+                enddo
+                ! North of the current latitude
+                do jj = j,jd
+                    qe(i,jj) = pv(i,jj+jd-1,k)-qref(j,k)*cor   !qe; Q = qref*cor
+                    ue(i,jj) = uu(i,jj+jd-1,k)-uref(j,k)       !ue
+                    aa = a*dp*cosphi(jj)                       !length element
+                    if(qe(i,jj).le.0.) then                    !LWA*cos(phi) and F2
+                        astar(i,j,k)=astar(i,j,k)-qe(i,jj)*aa
+                        ua2(i,j,k) = ua2(i,j,k)-qe(i,jj)*ue(i,jj)*aa
                     endif  
                 enddo
 
@@ -71,23 +84,15 @@ SUBROUTINE compute_lwa_and_barotropic_fluxes(nlon, nlat, kmax, jd, &
                 ep11 = ep11*(r/h)*exp(-rkappa*zz/h)
                 ep11 = ep11*2.*dz/(tg(k+1)-tg(k-1))
                 ep1(i,j,k) = ep1(i,j,k)-ep11                   !F3
-                phip = dp*float(j)                       
-                cosp = cos(phip)          ! cosine for one grid north
-                phi0 = dp*float(j-1)
-                cos0 = cos(phi0)          ! cosine for latitude grid
-                sin0 = sin(phi0)          ! sine for latitude grid
-                phim = dp*float(j-2)
-                cosm = cos(phim)          ! cosine for one grid south
-                ep1(i,j,k) = ep1(i,j,k)*cos0 ! correct for cosine factor
-
+                ep1(i,j,k) = ep1(i,j,k)*cosphi(j) ! correct for cosine factor
 
                 ! meridional eddy momentum flux one grid north and south
-                ep2(i,j,k)=(uu(i,j+jd,k)-uref(j,k))*vv(i,j+jd,k)*cosp*cosp
-                ep3(i,j,k)=(uu(i,j+jd-2,k)-uref(j,k))*vv(i,j+jd-2,k)*cosm*cosm
+                ep2(i,j,k)=(uu(i,j+jd  ,k)-uref(j,k))*vv(i,j+jd  ,k)*cosphi(j+1)*cosphi(j+1)
+                ep3(i,j,k)=(uu(i,j+jd-2,k)-uref(j,k))*vv(i,j+jd-2,k)*cosphi(j-1)*cosphi(j-1)
 
                 ! low-level meridional eddy heat flux
                 if(k.eq.2) then     ! (26) of SI-HN17
-                    ep41 = 2.*om*sin0*cos0*dz/prefactor       ! prefactor
+                    ep41 = 2.*om*sinphi(j)*cosphi(j)*dz/prefactor       ! prefactor
                     ep42 = exp(-dz/h)*vv(i,j+jd-1,2)*(pt(i,j+jd-1,2)-tref(j,2))
                     ep42 = ep42/(tg(3)-tg(1))
                     ep43 = vv(i,j+jd-1,1)*(pt(i,j+jd-1,1)-tref(j,1))


### PR DESCRIPTION
Hi, these changes to the Fortran code should speed up the computation of LWA and the fluxes by about a factor of 2.

Most of the speed-up comes from pre-computing the trigonometric functions. The loop splitting only helps a little. I added an `implicit none` at the beginning of the subroutine while I was at it and cleaned up some of the variable declarations/assignments (some were unused or not declared).

On my laptop, the wall time required to run `examples/demo_script_for_nh2018.ipynb` is reduced from 45 to 20 seconds. Comparing the output files before and after the changes, there are only very minor differences in the fields. A quick comparison

```python
import xarray as xr
import numpy as np

before = xr.load_dataset("2005-01-23_to_2005-01-30_output-before.nc")
after  = xr.load_dataset("2005-01-23_to_2005-01-30_output-after.nc")

for v in before.data_vars:
    b = before[v].values
    a = after[v].values
    mask = (b == a) | (np.isnan(b) & np.isnan(a))
    if not np.all(mask):
        print(v)
        print(b[~mask])
        print(a[~mask])
```

yields

```
Zonal advective flux F3
[-4.8969465e+32 -1.5369044e+35 -3.9752513e+35]
[-4.9222105e+32 -1.5369297e+35 -3.9752766e+35]
Zonal advective flux Convergence -Div(F1+F2+F3)
[-2.0668405e+35 -2.4852270e+35]
[-2.0668659e+35 -2.4852272e+35]
```

These values seem quite dodgy even in the before version, so I think it's fine.

Btw, I had to introduce a fill value in the `cosphi` and `sinphi` arrays at index 0 to avoid an out-of-bounds access in the computation of `ep3`, where index `j-1` is accessed which is `0` for `j=1`. As far as I can tell, the angle `phim` used before for this calculation was negative. This seemed weird and I've chosen an angle of 0 instead. Maybe inserting `NaN` would be a better choice or should I have kept the negative angle?