### PR TITLE
bugfix in fortran files

### DIFF
--- a/hn2016_falwa/f90_modules/compute_flux_dirinv.f90
+++ b/hn2016_falwa/f90_modules/compute_flux_dirinv.f90
@@ -97,8 +97,8 @@ SUBROUTINE compute_flux_dirinv(pv,uu,vv,pt,tn0,qref,uref,tref,&
 
 
         ! meridional eddy momentum flux one grid north and south
-        ep2(i,j)=(uu(i,j+91,k)-uref(j-jb,k))*vv(i,j+91,k)*cosp*cosp
-        ep3(i,j)=(uu(i,j+89,k)-uref(j-jb,k))*vv(i,j+89,k)*cosm*cosm
+        ep2(i,j)=(uu(i,j+nd,k)-uref(j-jb,k))*vv(i,j+nd,k)*cosp*cosp
+        ep3(i,j)=(uu(i,j+(nd-2),k)-uref(j-jb,k))*vv(i,j+(nd-2),k)*cosm*cosm
 
         ! low-level meridional eddy heat flux
         if(k.eq.2) then     ! (26) of SI-HN17

--- a/hn2016_falwa/f90_modules/compute_qref_and_fawa_first.f90
+++ b/hn2016_falwa/f90_modules/compute_qref_and_fawa_first.f90
@@ -40,14 +40,14 @@ SUBROUTINE compute_qref_and_fawa_first(pv, uu, vort, pt, tn0, imax, JMAX, kmax, 
 
 
   ! **** Zonal-mean field ****
-  do j = 91,jmax
-    qbar(j-90,:) = 0.
-    tbar(j-90,:) = 0.
-    ubar(j-90,:) = 0.
+  do j = nd,jmax
+    qbar(j-(nd-1),:) = 0.
+    tbar(j-(nd-1),:) = 0.
+    ubar(j-(nd-1),:) = 0.
     do i = 1,imax
-      qbar(j-90,:) = qbar(j-90,:)+pv(i,j,:)/float(imax)
-      tbar(j-90,:) = tbar(j-90,:)+pt(i,j,:)/float(imax)
-      ubar(j-90,:) = ubar(j-90,:)+uu(i,j,:)/float(imax)
+      qbar(j-(nd-1),:) = qbar(j-(nd-1),:)+pv(i,j,:)/float(imax)
+      tbar(j-(nd-1),:) = tbar(j-(nd-1),:)+pt(i,j,:)/float(imax)
+      ubar(j-(nd-1),:) = ubar(j-(nd-1),:)+uu(i,j,:)/float(imax)
     enddo
   enddo
 
@@ -162,7 +162,7 @@ SUBROUTINE compute_qref_and_fawa_first(pv, uu, vort, pt, tn0, imax, JMAX, kmax, 
   ! **** top boundary condition (Eqs. 24-25) *****
   tjk(:,:) = 0.
   sjk(:,:,:) = 0.
-  do jj = jb+2,90
+  do jj = jb+2,(nd-1)
     j = jj-jb
     phi0 = float(jj-1)*dp
     cos0 = cos(phi0)

--- a/hn2016_falwa/f90_modules/matrix_b4_inversion.f90
+++ b/hn2016_falwa/f90_modules/matrix_b4_inversion.f90
@@ -23,7 +23,7 @@ SUBROUTINE matrix_b4_inversion(k,jmax,kmax,nd,jb,jd,z,statn,qref,ckref,&
   qjj(:,:) = 0.
   sjj(:,:) = sjk(:,:,k)
   tj(:) = tjk(:,k)
-  do jj = jb+2,90
+  do jj = jb+2,(nd-1)
     j = jj - jb
     phi0 = float(jj-1)*dp
     phip = (float(jj)-0.5)*dp


### PR DESCRIPTION
There were resolution-dependent procedures which worked with the (360x181) grid we used for NHN2022, GRL. This bugfix enables the new inversion routine to take data of other grid sizes.