### PR TITLE
Add TeXed overview of how output fields correspond to budget terms

### DIFF
--- a/docs/source/Object Oriented Interface.rst
+++ b/docs/source/Object Oriented Interface.rst
@@ -7,4 +7,46 @@ Object Oriented Interface
    :members:
 
 
+Terms in the LWA Column Budget
+------------------------------
+
+With the LWA column budget as formulated by `Neal et al. <https://doi.org/10.1029/2021GL097699>`_ (2022, supporting information, equations 5-7), the output fields of :py:meth:`QGField.compute_lwa_and_barotropic_fluxes` correspond to terms as follows:
+
+.. math::
+
+   \frac{\partial}{\partial t} \boxed{ \langle A \rangle \cos(\phi) }_\mathtt{~lwa\_baro} ~ = ~
+        & \boxed{ - \frac{1}{a \cos(\phi)} \frac{\partial}{\partial \lambda} \langle F_{\lambda} \rangle }_\mathtt{~convergence\_zonal\_advective\_flux} \\
+        & \boxed{ - \frac{1}{a \cos(\phi)} \frac{\partial}{\partial \phi'} \langle F_{\phi'} \cos(\phi + \phi') \rangle }_\mathtt{~divergence\_eddy\_momentum\_flux} \\
+        & \boxed{ + \frac{f \cos(\phi)}{H} \left( \frac{v_e \theta_e}{\partial \tilde\theta / \partial z} \right)_{z=0} }_\mathtt{~meridional\_heat\_flux} \\
+        & + \langle \dot A \rangle \cos(\phi) \\
+
+   \langle F_{\lambda} \rangle ~ = ~
+        & \boxed{ \langle u_\mathrm{REF} A \cos(\phi) \rangle }_\mathtt{~adv\_flux\_f1} \\
+        & \boxed{ - a \left\langle \int_0^{\Delta\phi} u_e q_e \cos(\phi + \phi') \mathrm{d}\phi' \right\rangle }_\mathtt{~adv\_flux\_f2} \\
+        & \boxed{ + \frac{\cos(\phi)}{2} \left\langle v_e^2 - u_e^2 - \frac{R}{H} \frac{e^{-\kappa z / H} \theta_e^2}{\partial \tilde\theta / \partial z} \right\rangle }_\mathtt{~adv\_flux\_f3} \\
+
+   \langle F_{\phi'} \rangle ~ = ~
+        & - \langle u_e v_e A \cos(\phi + \phi') \rangle
+
+
+.. note::
+    
+    The `dirinv`-based routines added in version 0.6 as an alternative to the `SOR`-based routines are still considered experimental.
+    The output fields of :py:meth:`QGField._compute_lwa_flux_dirinv` correspond to the terms of the LWA budget in the following way:
+
+    .. math::
+
+       \frac{\partial}{\partial t} \boxed{ \langle A \rangle \cos(\phi) }_\mathtt{~astarbaro} ~ = ~
+            & - \frac{1}{a \cos(\phi)} \frac{\partial}{\partial \lambda} \langle F_{\lambda} \rangle \\
+            & - \frac{1}{a \cos(\phi)} \frac{\partial}{\partial \phi'} \boxed{ \langle F_{\phi'} \cos(\phi + \phi') \rangle }_{~\mathtt{~ep2baro} \mathrm{(north)}, \mathtt{ep3baro} \mathrm{(south)}} \\
+            & \boxed{ + \frac{f \cos(\phi)}{H} \left( \frac{v_e \theta_e}{\partial \tilde\theta / \partial z} \right)_{z=0} }_\mathtt{~ep4} \\
+            & + \langle \dot A \rangle \cos(\phi) \\
+
+       \langle F_{\lambda} \rangle ~ = ~
+            & \boxed{ \langle u_\mathrm{REF} A \cos(\phi) \rangle }_\mathtt{~ua1baro} \\
+            & \boxed{ - a \left\langle \int_0^{\Delta\phi} u_e q_e \cos(\phi + \phi') \mathrm{d}\phi' \right\rangle }_\mathtt{~ua2baro} \\
+            & \boxed{ + \frac{\cos(\phi)}{2} \left\langle v_e^2 - u_e^2 - \frac{R}{H} \frac{e^{-\kappa z / H} \theta_e^2}{\partial \tilde\theta / \partial z} \right\rangle }_\mathtt{~ep1baro} \\
+
+       \langle F_{\phi'} \rangle ~ = ~
+            & - \langle u_e v_e A \cos(\phi + \phi') \rangle
 

--- a/hn2016_falwa/xarrayinterface.py
+++ b/hn2016_falwa/xarrayinterface.py
@@ -494,8 +494,8 @@ def integrate_budget(ds, var_names=None):
 
     Integrates the LWA tendencies from equation (2) of `NH18
     <https://doi.org/10.1126/science.aat0721>`_ in time (over the time interval
-    covered by in the input data). The residual (term IV) is determined by
-    subtracting terms (I), (II) and (II) from the LWA difference between the
+    covered by the input data). The residual (term IV) is determined by
+    subtracting terms (I), (II) and (III) from the LWA difference between the
     last and first time step in the data. Uses
     :py:meth:`xarray.DataArray.integrate` for the time integration of the
     tendencies.


### PR DESCRIPTION
Hi @csyhuang,

While the correspondence of the output fields to the terms of the LWA column budget equation is stated in the docstring of `QGField.compute_lwa_and_barotropic_fluxes()`, I thought it might be nice to add a summary with TeXed formulas to the documentation:

![image](https://user-images.githubusercontent.com/11723107/206419779-b333d62d-6c68-4578-8177-9fe5247f306e.png)

I've also added an overview for the output fields of `QGField._compute_lwa_flux_dirinv()`. The *dirinv*-functions don't show up in the documentation yet, but it seems that some people use them already so maybe it's helpful.

`sphinx.ext.imgmath` is already a requirement for building the documentation, so no changes to the build process are necessary.

Cheers,
Christopher