### PR TITLE
Package installation broken: fix for setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,40 +22,40 @@ LONG_DESCRIPTION =\
     - Source code: http://github.com/csyhuang/hn2016_falwa/
     """
 
-ext1 = Extension(name='interpolate_fields',
+ext1 = Extension(name='hn2016_falwa.interpolate_fields',
                  sources=['hn2016_falwa/f90_modules/interpolate_fields.f90'],
                  f2py_options=['--quiet'])
 
-ext2 = Extension(name='compute_reference_states',
+ext2 = Extension(name='hn2016_falwa.compute_reference_states',
                  sources=['hn2016_falwa/f90_modules/compute_reference_states.f90'],
                  f2py_options=['--quiet'])
 
-ext3 = Extension(name='compute_lwa_and_barotropic_fluxes',
+ext3 = Extension(name='hn2016_falwa.compute_lwa_and_barotropic_fluxes',
                  sources=['hn2016_falwa/f90_modules/compute_lwa_and_barotropic_fluxes.f90'],
                  f2py_options=['--quiet'])
 
 # *** Extensions 4-9 are used by the direct inversion algorithm ***
-ext4 = Extension(name='interpolate_fields_direct_inv',
+ext4 = Extension(name='hn2016_falwa.interpolate_fields_direct_inv',
                  sources=['hn2016_falwa/f90_modules/interpolate_fields_dirinv.f90'],
                  f2py_options=['--quiet'])
 
-ext5 = Extension(name='compute_qref_and_fawa_first',
+ext5 = Extension(name='hn2016_falwa.compute_qref_and_fawa_first',
                  sources=['hn2016_falwa/f90_modules/compute_qref_and_fawa_first.f90'],
                  f2py_options=['--quiet'])
 
-ext6 = Extension(name='matrix_b4_inversion',
+ext6 = Extension(name='hn2016_falwa.matrix_b4_inversion',
                  sources=['hn2016_falwa/f90_modules/matrix_b4_inversion.f90'],
                  f2py_options=['--quiet'])
 
-ext7 = Extension(name='matrix_after_inversion',
+ext7 = Extension(name='hn2016_falwa.matrix_after_inversion',
                  sources=['hn2016_falwa/f90_modules/matrix_after_inversion.f90'],
                  f2py_options=['--quiet'])
 
-ext8 = Extension(name='upward_sweep',
+ext8 = Extension(name='hn2016_falwa.upward_sweep',
                  sources=['hn2016_falwa/f90_modules/upward_sweep.f90'],
                  f2py_options=['--quiet'])
 
-ext9 = Extension(name='compute_flux_dirinv',
+ext9 = Extension(name='hn2016_falwa.compute_flux_dirinv',
                  sources=['hn2016_falwa/f90_modules/compute_flux_dirinv.f90'],
                  f2py_options=['--quiet'])
 
@@ -68,8 +68,7 @@ setup(
     author='Clare S. Y. Huang',
     author_email='csyhuang@protonmail.com',
     license='MIT',
-    package_dir={"": "hn2016_falwa"},
-    packages=find_packages(where="hn2016_falwa"),
+    packages=find_packages(),
     setup_requires=['pytest-runner'],
     tests_require=['pytest'],
     extras_require={"Xarray": ["xarray"]},
@@ -77,3 +76,4 @@ setup(
     ext_modules=[ext1, ext2, ext3, ext4, ext5, ext6, ext7, ext8, ext9],
     zip_safe=False
 )
+


### PR DESCRIPTION
Hi Clare,

I wanted to update to 0.6.4 today and on two machines I cannot import the package after installation. Doesn't matter if I install from PyPI or locally with the repo. I always get `ModuleNotFoundError: No module named 'hn2016_falwa'` even though the package shows up in `pip list`.

With a few changes in the `setup.py`, the package can be imported after installation: (see attached commit)

- Add `hn2016_falwa.` before all 9 extension names.
- Remove `package_dir` arg from `setup` call.
- Remove `where` arg in `find_packages` call.

I don't really know what `package_dir` does, so I'm not sure what exactly I have changed here.

If I look into the files currently distributed on PyPI (https://pypi.org/project/hn2016-falwa/#files), the .py files all seem to be missing in the package. Same thing happens when I look into the site_packages after installing from the repository locally. This changes after applying the attached fix for `setup.py`.

I would appreciate if you could double check.