### PR TITLE
Documentation changes for release 0.7.0

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,6 +2,7 @@
 sphinx==3.2.1
 sphinx_rtd_theme==1.0.0
 readthedocs-sphinx-search==0.1.1
+nbsphinx
 numpy
 scipy
 xarray

--- a/docs/source/Data Storage.rst
+++ b/docs/source/Data Storage.rst
@@ -3,8 +3,12 @@
 Data Storage
 =============
 
-This is a class that manages derived physical quantities within QGField. This is only for internal use
-of `QGField`. Users shall access computed quantities via the properties of `QGField`.
+These classes manage derived physical quantities within :py:class:`oopinterface.QGField`.
+
+.. warning::
+    This is only for internal use of :py:class:`oopinterface.QGField`.
+    Users shall access computed quantities via the properties of :py:class:`oopinterface.QGField`.
+
 
 .. automodule:: data_storage
    :members:

--- a/docs/source/Example Notebooks.rst
+++ b/docs/source/Example Notebooks.rst
@@ -1,0 +1,19 @@
+Example Notebooks
+=================
+
+
+.. toctree::
+   :maxdepth: 2
+
+   notebooks/demo_script_for_nh2018
+   notebooks/demo_script_for_nh2018_with_xarray
+   notebooks/nhn22_reference_states
+
+
+.. toctree::
+   :maxdepth: 1
+
+   notebooks/Example_barotropic
+   notebooks/Example_qgpv
+   notebooks/BarotropicField_example
+

--- a/docs/source/Object Oriented Interface.rst
+++ b/docs/source/Object Oriented Interface.rst
@@ -1,5 +1,3 @@
-
-
 Object Oriented Interface
 ==========================
 
@@ -10,20 +8,12 @@ Object Oriented Interface
 Terms in the LWA Column Budget
 ------------------------------
 
-There are two sets of methods to compute the LWA column budget available in this class:
+There are two sets of methods to compute the LWA column budget available:
 
-1. `Nakamura and Huang, Science (2018) <https://www.science.org/doi/10.1126/science.aat0721>`_ : eq (2), (3) with reference states solved with boundary conditions (S4).
-    The corresponding methods of flux computation are:
-        1. `interpolate_fields`
-        2. `compute_reference_states`: matrix inversion is done using `SOR <https://github.com/csyhuang/hn2016_falwa/blob/master/notes/SOR_solver_for_NH18.pdf>`_
-        3. `compute_lwa_and_barotropic_fluxes`
-
-
-2. `Neal et al., GRL (2022) <https://doi.org/10.1029/2021GL097699>`_ : eq (S5) - (S7) with reference states solved with boundary conditions (S14) - (S16).
-    The corresponding methods of flux computation are:
-        1. `_interpolate_field_dirinv`
-        2. `_compute_qref_fawa_and_bc`: since the latitudinal boundary is now away from the equator, solution is guaranteed such that `Direct Inversion <https://github.com/csyhuang/hn2016_falwa/blob/master/notes/Direct_solver_for_NHN22.pdf>`_ is implemented.
-        3. `_compute_lwa_flux_dirinv`
+1. `Nakamura and Huang, Science (2018) <https://www.science.org/doi/10.1126/science.aat0721>`_ : :py:class:`QGFieldNH18`.
+    Eq (2), (3) with reference states solved with boundary conditions (S4) and `SOR <https://github.com/csyhuang/hn2016_falwa/blob/master/notes/SOR_solver_for_NH18.pdf>`_.
+2. `Neal et al., GRL (2022) <https://doi.org/10.1029/2021GL097699>`_ : :py:class:`QGFieldNHN22`.
+    Eq (S5) - (S7) with reference states solved with boundary conditions (S14) - (S16) and `direct inversion <https://github.com/csyhuang/hn2016_falwa/blob/master/notes/Direct_solver_for_NHN22.pdf>`_ (since the latitudinal boundary is away from the equator, solution is guaranteed).
 
 With the LWA column budget as formulated by `Nakamura and Huang, Science (2018) <https://www.science.org/doi/10.1126/science.aat0721>`_, the output fields of :py:meth:`QGField.compute_lwa_and_barotropic_fluxes` correspond to terms as follows:
 
@@ -43,9 +33,13 @@ With the LWA column budget as formulated by `Nakamura and Huang, Science (2018) 
 
 .. note::
     
-    The `dirinv`-based routines used in `Neal et al., GRL (2022) <https://doi.org/10.1029/2021GL097699>`_ added in release 0.6.0 are encapsulated in implicit functions (which will be public in release 0.7.0).
+    Before version 0.7.0, the routines used in `Neal et al., GRL (2022) <https://doi.org/10.1029/2021GL097699>`_ were encapsulated in implicit functions:
 
-    The output fields of :py:meth:`QGField._compute_lwa_flux_dirinv` correspond to the terms of the LWA budget in the following way:
+        1. `_interpolate_field_dirinv`
+        2. `_compute_qref_fawa_and_bc`
+        3. `_compute_lwa_flux_dirinv`
+
+    With output fields of `_compute_lwa_flux_dirinv` corresponding to the terms of the LWA budget in the following way:
 
     .. math::
 
@@ -63,4 +57,3 @@ With the LWA column budget as formulated by `Nakamura and Huang, Science (2018) 
        \langle F_{\phi'} \rangle ~ = ~
             & - \langle u_e v_e A \cos(\phi + \phi') \rangle
 
-    At the mean time, if you want to use this set of routine, please refer to ``scripts/nhn_grl2022/sample_run_script.py`` for the usage.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -52,7 +52,8 @@ extensions = ['sphinx.ext.autodoc',
               'sphinx.ext.imgmath',
               'sphinx.ext.viewcode',
               'sphinx.ext.napoleon',
-              'sphinx_rtd_theme']
+              'sphinx_rtd_theme',
+              'nbsphinx']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -88,6 +88,7 @@ Modules
    Utility Functions
    Wrapper Functions
    Data Storage
+   Example Notebooks
 
 
 Indices and tables

--- a/docs/source/modules.rst
+++ b/docs/source/modules.rst
@@ -1,8 +1,0 @@
-build
-=====
-
-.. toctree::
-   :maxdepth: 5
-   
-   
-

--- a/docs/source/notebooks/BarotropicField_example.ipynb
+++ b/docs/source/notebooks/BarotropicField_example.ipynb
@@ -1,0 +1,1 @@
+../../../notebooks/simple/BarotropicField_example.ipynb

--- a/docs/source/notebooks/Example_barotropic.ipynb
+++ b/docs/source/notebooks/Example_barotropic.ipynb
@@ -1,0 +1,1 @@
+../../../notebooks/simple/Example_barotropic.ipynb

--- a/docs/source/notebooks/Example_qgpv.ipynb
+++ b/docs/source/notebooks/Example_qgpv.ipynb
@@ -1,0 +1,1 @@
+../../../notebooks/simple/Example_qgpv.ipynb

--- a/docs/source/notebooks/demo_script_for_nh2018.ipynb
+++ b/docs/source/notebooks/demo_script_for_nh2018.ipynb
@@ -1,0 +1,1 @@
+../../../notebooks/nh2018_science/demo_script_for_nh2018.ipynb

--- a/docs/source/notebooks/demo_script_for_nh2018_with_xarray.ipynb
+++ b/docs/source/notebooks/demo_script_for_nh2018_with_xarray.ipynb
@@ -1,0 +1,1 @@
+../../../notebooks/nh2018_science/demo_script_for_nh2018_with_xarray.ipynb

--- a/docs/source/notebooks/nhn22_reference_states.ipynb
+++ b/docs/source/notebooks/nhn22_reference_states.ipynb
@@ -1,0 +1,1 @@
+../../../notebooks/nh2018_science/nhn22_reference_states.ipynb

--- a/hn2016_falwa/barotropic_field.py
+++ b/hn2016_falwa/barotropic_field.py
@@ -33,8 +33,10 @@ class BarotropicField(object):
             Absolute vorticity field with dimension [nlat x nlon]. If 'pv_field=None': pv_field is expected to be computed with u,v,t field.
 
 
-    Example
-    ---------
+    Examples
+    --------
+    :doc:`Example Notebook <notebooks/Example_qgpv>`
+
     >>> barofield1 = BarotropicField(xlon, ylat, pv_field=abs_vorticity)
 
     """

--- a/hn2016_falwa/data_storage.py
+++ b/hn2016_falwa/data_storage.py
@@ -65,9 +65,11 @@ class SHemProperty(HemisphericProperty):
 
 class DerivedQuantityStorage:
     """
-    This class manages the storage of derived variables in QGField (for internal use only).
-    Variables are stored in fortran indexing order for easy communication with f2py modules.
-    To return variables in python indexing order, use the method `fortran_to_python` to swap the axes.
+    This class manages the storage of derived variables in :py:class:`oopinterface.QGField`.
+
+    Variables are stored in fortran indexing order for easy communication with
+    f2py modules. To return variables in python indexing order, use the method
+    :py:meth:`fortran_to_python` to swap the axes.
     """
     def __init__(
         self, pydim: Union[int, Tuple], fdim: Union[int, Tuple],
@@ -108,6 +110,7 @@ class DerivedQuantityStorage:
 class DomainAverageStorage(DerivedQuantityStorage):
     """
     This stores global/hemispheric averaged potential temperature and static stability.
+
     Fortran dimension: (kmax)
     """
     def __init__(self, pydim: Union[int, Tuple], fdim: Union[int, Tuple],
@@ -124,10 +127,12 @@ class DomainAverageStorage(DerivedQuantityStorage):
 class InterpolatedFieldsStorage(DerivedQuantityStorage):
     """
     This class stores 3D fields on interpolated grids, including:
-        - u
-        - v
-        - t (potential temperature)
-        - avort (absolute vorticity, used as boundary condition to solve for reference state in NHN22)
+
+    - u
+    - v
+    - theta (potential temperature)
+    - avort (absolute vorticity, used as boundary condition to solve for reference state in NHN22)
+
     Fortran dimension: (nlon, nlat, kmax)
     """
     def __init__(self, pydim: Union[int, Tuple], fdim: Union[int, Tuple],
@@ -143,9 +148,11 @@ class InterpolatedFieldsStorage(DerivedQuantityStorage):
 class ReferenceStatesStorage(DerivedQuantityStorage):
     """
     This class stores height-latitude 2D fields on interpolated grids, including:
-        - uref
-        - qref (it actually stores qref/f, where f is Coriolis paramter)
-        - tref (potential temperature reference state)
+
+    - uref
+    - qref (it actually stores qref/f, where f is Coriolis paramter)
+    - tref (potential temperature reference state)
+
     Fortran dimension: (nlat, kmax)
     """
     def __init__(self, pydim: Union[int, Tuple], fdim: Union[int, Tuple],
@@ -181,6 +188,7 @@ class ReferenceStatesStorage(DerivedQuantityStorage):
 class LWAStorage(DerivedQuantityStorage):
     """
     This class stores 3D LWA field on interpolated grids.
+
     Fortran dimension: (nlon, nlat, kmax)
     """
     def __init__(self, pydim: Union[int, Tuple], fdim: Union[int, Tuple],
@@ -197,13 +205,15 @@ class LWAStorage(DerivedQuantityStorage):
 class OutputBarotropicFluxTermsStorage(DerivedQuantityStorage):
     """
     This class stores vertically integrated derived quantities in latitude-longitude 2D grid, including:
-        - adv_flux_f1
-        - adv_flux_f2
-        - adv_flux_f3
-        - zonal_adv_flux
-        - convergence_zonal_advective_flux
-        - divergence_eddy_momentum_flux
-        - meridional_heat_flux
+
+    - adv_flux_f1
+    - adv_flux_f2
+    - adv_flux_f3
+    - zonal_adv_flux
+    - convergence_zonal_advective_flux
+    - divergence_eddy_momentum_flux
+    - meridional_heat_flux
+
     Variables are stored in **python indexing order**: (nlat, nlon)
     """
     def __init__(self, pydim: Union[int, Tuple], fdim: Union[int, Tuple],
@@ -223,6 +233,7 @@ class OutputBarotropicFluxTermsStorage(DerivedQuantityStorage):
 class BarotropicFluxTermsStorage(DerivedQuantityStorage):
     """
     This class stores intermediate computed quantities in latitude-longitude 2D grid.
+
     Variables are stored in fortran indexing order: (nlon, nlat)
     """
     def __init__(self, pydim: Union[int, Tuple], fdim: Union[int, Tuple],

--- a/hn2016_falwa/oopinterface.py
+++ b/hn2016_falwa/oopinterface.py
@@ -865,10 +865,13 @@ class QGFieldNH18(QGField):
         https://www.science.org/doi/10.1126/science.aat0721
 
     See the documentation of :py:class:`QGField` for the public interface.
-
     There are no additional arguments for this class.
 
     .. versionadded:: 0.7.0
+
+    Examples
+    --------
+    :doc:`notebooks/demo_script_for_nh2018`
     """
 
     def _interpolate_fields(self, Interpolated_fields_to_return):
@@ -998,6 +1001,10 @@ class QGFieldNHN22(QGField):
         to be the absolute vorticity. This parameter specify the location of grid point (from equator)
         which will be used as boundary. The results in NHN22 is produced by using 1 deg latitude data and
         eq_boundary_index = 5, i.e. using a latitude domain from 5 deg to the pole. Default = 5 here.
+
+    Examples
+    --------
+    Notebook: :doc:`notebooks/nhn22_reference_states`
     """
     def __init__(self, xlon, ylat, plev, u_field, v_field, t_field, kmax=49, maxit=100000, dz=1000., npart=None,
                  tol=1.e-5, rjac=0.95, scale_height=SCALE_HEIGHT, cp=CP, dry_gas_constant=DRY_GAS_CONSTANT,

--- a/hn2016_falwa/oopinterface.py
+++ b/hn2016_falwa/oopinterface.py
@@ -26,10 +26,15 @@ from collections import namedtuple
 class QGField(object):
 
     """
-    Local wave activity and flux analysis in quasi-geostrophic framework
-    that can be used to reproduce the results in:
-    Nakamura and Huang, Atmospheric Blocking as a Traffic Jam in the Jet Stream, Science (2018).
-    Note that topography is assumed flat in this object.
+    Local wave activity and flux analysis in the quasi-geostrophic framework.
+
+    .. warning::
+        This is an abstract class that defines the public interface but does
+        not define any boundary conditions for the reference state computation.
+        Instanciate via the specific child classes :py:class:`QGFieldNH18` or
+        :py:class:`QGFieldNHN22` to select the desired boundary conditions.
+
+    Topography is assumed flat in this object.
 
     .. versionadded:: 0.3.0
 
@@ -854,14 +859,16 @@ class QGField(object):
 
 class QGFieldNH18(QGField):
     """
-    This child class of QGField implements the procedures and compute reference states with the set of
-    boundary conditions specified in NH18:
+    Procedures and reference state computation with the set of boundary conditions of NH18:
+
         Nakamura, N., & Huang, C. S. (2018). Atmospheric blocking as a traffic jam in the jet stream. Science, 361(6397), 42-47.
         https://www.science.org/doi/10.1126/science.aat0721
 
-    .. versionadded:: 0.7.0
+    See the documentation of :py:class:`QGField` for the public interface.
 
-    See documentation of QGField for the public interface. There is no additional arguments for this class.
+    There are no additional arguments for this class.
+
+    .. versionadded:: 0.7.0
     """
 
     def _interpolate_fields(self, Interpolated_fields_to_return):
@@ -974,15 +981,15 @@ class QGFieldNH18(QGField):
 
 class QGFieldNHN22(QGField):
     """
-    This child class of QGField implements the procedures and compute reference states with the set of
-    boundary conditions specified in NHN22:
+    Procedures and reference state computation with the set of boundary conditions of NHN22:
+
         Neal et al (2022). The 2021 Pacific Northwest heat wave and associated blocking: meteorology and the role of an
-        upstream cyclone as a diabatic source of wave activity
+        upstream cyclone as a diabatic source of wave activity.
         https://agupubs.onlinelibrary.wiley.com/doi/full/10.1029/2021GL097699
 
-    .. versionadded:: 0.7.0
+    See the documentation of :py:class:`QGField` for the public interface.
 
-    See documentation of QGField for the public interface.
+    .. versionadded:: 0.7.0
 
     Parameters
     ----------

--- a/hn2016_falwa/wrapper.py
+++ b/hn2016_falwa/wrapper.py
@@ -34,6 +34,10 @@ def barotropic_eqlat_lwa(ylat, vort, area, dmu, n_points, planet_radius=EARTH_RA
     lwa_result : numpy.ndarray
         2-d numpy array of local wave activity values;
                     dimension = [nlat_s x nlon]
+
+    Examples
+    --------
+    :doc:`Example Notebook <notebooks/Example_barotropic>`
     """
     nlat = vort.shape[0]
     nlon = vort.shape[1]
@@ -222,6 +226,9 @@ def qgpv_eqlat_lwa(ylat, vort, area, dmu, nlat_s=None, n_points=None, planet_rad
         2-d numpy array of local wave activity values;
                     dimension = [nlat_s x nlon]
 
+    Examples
+    --------
+    :doc:`Example Notebook <notebooks/Example_qgpv>`
     """
     nlat = vort.shape[0]
     nlon = vort.shape[1]

--- a/hn2016_falwa/xarrayinterface.py
+++ b/hn2016_falwa/xarrayinterface.py
@@ -100,8 +100,11 @@ class QGDataset:
         a lookup table that maps `plev`, `ylat`, `xlon`, `u`, `v` and/or `t` to
         the names used in the dataset.
 
-    Example
+    Examples
     -------
+
+    :doc:`notebooks/demo_script_for_nh2018_with_xarray`
+
     >>> data_u = xarray.load_dataset("path/to/some/u-data.nc")
     >>> data_v = xarray.load_dataset("path/to/some/v-data.nc")
     >>> data_t = xarray.load_dataset("path/to/some/t-data.nc")
@@ -531,7 +534,7 @@ def integrate_budget(ds, var_names=None):
     -------
     xarray.Dataset
 
-    Example
+    Examples
     -------
     >>> qgds = QGDataset(data)
     >>> terms = qgds.compute_lwa_and_barotropic_fluxes()

--- a/notebooks/nh2018_science/demo_script_for_nh2018.ipynb
+++ b/notebooks/nh2018_science/demo_script_for_nh2018.ipynb
@@ -47,7 +47,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Load ERA-Interim reanalysis data retrieved from ECMWF server\n",
+    "## Load ERA-Interim reanalysis data retrieved from ECMWF server\n",
     "The sample script in this directory `download_example.py` include the code to retrieve zonal wind field U, meridional\n",
     "wind field V and temperature field T at various pressure levels. Given that you have an account on ECMWF server and\n",
     "have the `ecmwfapi` package installed, you can run the scripts to download data from there:\n",
@@ -87,7 +87,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Load the dimension arrays\n",
+    "## Load the dimension arrays\n",
     "In this version, the `QGField` object takes only:\n",
     "- latitude array in degree ascending order, and \n",
     "- pressure level in hPa in decending order (from ground to aloft)."
@@ -159,7 +159,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Create a netCDF file to store output\n",
+    "## Create a netCDF file to store output\n",
     "\n",
     "A netCDF file `2005-01-23_to_2005-01-30_output.nc` with same number of time steps in the input file is created to store all the computed quantities."
    ]
@@ -228,7 +228,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Set the level of pressure and the timestamp to display below"
+    "## Set the level of pressure and the timestamp to display below"
    ]
   },
   {
@@ -246,14 +246,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Set names of the variables to display"
+    "## Set names of the variables to display"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Loop through the input file and store all the computed quantities in a netCDF file"
+    "## Loop through the input file and store all the computed quantities in a netCDF file"
    ]
   },
   {

--- a/notebooks/nh2018_science/demo_script_for_nh2018_with_xarray.ipynb
+++ b/notebooks/nh2018_science/demo_script_for_nh2018_with_xarray.ipynb
@@ -8,7 +8,7 @@
     "Last updated on May 17, 2023\n",
     "\n",
     "\n",
-    "# Demo script for the analyses done in Nakamura and Huang (2018, Science)\n",
+    "# Demo script for the analyses done in Nakamura and Huang (2018, Science): using xarray\n",
     "\n",
     "Companion notebook to [`demo_script_for_nh2018.ipynb`](demo_script_for_nh2018.ipynb), using the xarray interface."
    ]

--- a/notebooks/nh2018_science/nhn22_reference_states.ipynb
+++ b/notebooks/nh2018_science/nhn22_reference_states.ipynb
@@ -56,7 +56,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Sample data\n",
+    "## Sample data\n",
     "\n",
     "The netCDF dataset used below can be downloaded from [Clare's Dropbox folder](https://www.dropbox.com/scl/fo/b84pwlr7zzsndq8mpthd8/h/notebooks/nh2018_science?dl=0&subfolder_nav_tracking=1). It is retrieved from:\n",
     "https://cds.climate.copernicus.eu/#!/home"
@@ -93,7 +93,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Load the dimension arrays\n",
+    "## Load the dimension arrays\n",
     "In this version, the `QGField` object takes only:\n",
     "- latitude array in degree ascending order, and \n",
     "- pressure level in hPa in decending order (from ground to aloft)."
@@ -166,7 +166,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Create a netCDF file to store output\n",
+    "## Create a netCDF file to store output\n",
     "\n",
     "A netCDF file `2005-01-23_to_2005-01-30_output.nc` with same number of time steps in the input file is created to store all the computed quantities."
    ]
@@ -235,7 +235,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Set the level of pressure and the timestamp to display below"
+    "## Set the level of pressure and the timestamp to display below"
    ]
   },
   {
@@ -253,7 +253,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Additional parameters to compute reference state from NHN22 boundary conditions"
+    "## Additional parameters to compute reference state from NHN22 boundary conditions"
    ]
   },
   {
@@ -269,7 +269,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Loop through the input file and store all the computed quantities in a netCDF file"
+    "## Loop through the input file and store all the computed quantities in a netCDF file"
    ]
   },
   {

--- a/notebooks/simple/BarotropicField_example.ipynb
+++ b/notebooks/simple/BarotropicField_example.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Using object-oriented interface (*BarotropicField*)"
+    "# Using the object-oriented interface (`BarotropicField`)"
    ]
   },
   {

--- a/notebooks/simple/Example_barotropic.ipynb
+++ b/notebooks/simple/Example_barotropic.ipynb
@@ -6,6 +6,8 @@
    "source": [
     "Last updated on May 21, 2023\n",
     "\n",
+    "# Using `barotropic_qglat_lwa`\n",
+    "\n",
     "## Instructions\n",
     "\n",
     "This sample code demonstrate how the wrapper function \"barotropic_eqlat_lwa\" in thepython package \"hn2016_falwa\" computes the finite-amplitude local wave activity \n",

--- a/notebooks/simple/Example_qgpv.ipynb
+++ b/notebooks/simple/Example_qgpv.ipynb
@@ -4,6 +4,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "# Using `qgpv_eqlat_lwa`\n",
+    "\n",
     "## Instructions\n",
     "\n",
     "The python package \"hn2016_falwa\" contains a wrapper function named \"qgpv_eqlat_lwa\" that computes the finite-amplitude local wave activity (LWA) based on quasi-geostrophic potential vorticity (QGPV) field derived from Reanalysis data with spherical geometry. It differs from the function \"barotropic_eqlat_lwa\" that a hemispheric domain (instead of global domain) is used to compute both equivalent-latitude relationship and LWA. This is to avoid spurious large values of LWA near the equator arising from the small meridional gradient of QGPV there.\n",


### PR DESCRIPTION
A few commits to update parts of the documentation and integrate the example jupyter notebooks into the docs pages with nbsphinx (as suggested in #66).

- I added nbsphinx to the requirements.txt in the docs folder, but I don't know if that will be picked up by readthedocs.
- Some heading levels in the notebooks changed so they render appropriately in the documentation.
- I updated the description of the flux/budget terms now that the _dirinv interface is gone.
- A more prominent warning is now shown for QGField that users should instanciate with the child classes.

Btw: I think QGField needs to inherit from `abc.ABC` for the `@abstractmethod` to properly work. Or we could overwrite `__new__` in QGField to redirect to the NH18 constructor by default, which might help with backwards compatibility.