### PR TITLE
Docs fixes for v2.1.0

### DIFF
--- a/src/falwa/oopinterface.py
+++ b/src/falwa/oopinterface.py
@@ -1454,11 +1454,13 @@ class QGFieldNHN22(QGFieldBase):
         """
         Parameters
         ----------
-        heating_rate(np.array): the diabatic heating output from reanalysis data on pressure levels that has unit K/s.
+        heating_rate : np.array
+            The diabatic heating output from reanalysis data on pressure levels that has unit K/s.
 
         Returns
         -------
-        A numpy array that contains the ncforce term q_dot = f e^z/H d/dz(e{-z/H} \theta_dot / d\theta/dz)
+        np.ndarray
+            Array that contains the ncforce term q_dot = f e^z/H d/dz(e{-z/H} \\theta_dot / d\\theta/dz)
         """
 
         # Interpolate DTDTLWR onto regular z-grid first. Result has dimension (kmax, nlat, nlon)

--- a/src/falwa/utilities.py
+++ b/src/falwa/utilities.py
@@ -260,22 +260,24 @@ def z_derivative_of_prod(
     gfunc: np.ndarray, multiplier: np.ndarray):
     """
     Compute the expression:
-        f exp^{z/H} d/dz [ exp^{-z/H}/static_stability * g(z, \phi, \lambda) ]
+
+        f exp^{z/H} d/dz [ exp^{-z/H}/static_stability * g(z, \\phi, \\lambda) ]
 
     Parameters
     ----------
     stat_n : numpy.ndarray of dim (kmax). Static stability per pressure level.
     stat_s : numpy.ndarray of dim (kmax). Static stability per pressure level.
     kmax : integer. Number of pseudoheight levels.
-    equator_idx: integer. Latitudinal index of the equator (\phi = 0).
+    equator_idx: integer. Latitudinal index of the equator (\\phi = 0).
     dz : float. Differential element of pseudoheight.
     density_decay : numpy.ndarray of dim (kmax). Explicitly, exp^{-z/H}.
-    gfunc : numpy.ndarray of dim (kmax, nlat, nlon). Explicitly, g(z, \phi, \lambda)
+    gfunc : numpy.ndarray of dim (kmax, nlat, nlon). Explicitly, g(z, \\phi, \\lambda)
     multiplier: numpy.ndarray of dim (kmax, nlat). Explicitly, f * exp^{-z/H} where f is Coriolis parameter.
 
     Returns
     -------
-    A numpy.ndarray of dim (kmax, nlat, nlon) that is the result
+    numpy.ndarray
+        Array of dim (kmax, nlat, nlon) that is the result
     """
     # Make static_stability_temp (kmax, nlat) ndarray
     static_stability_temp = np.concatenate([

--- a/src/falwa/xarrayinterface.py
+++ b/src/falwa/xarrayinterface.py
@@ -584,11 +584,12 @@ class QGDataset:
         """
         Call `compute_ncforce_from_heating_rate` on all contained fields given heating rate input.
 
-        See :py:meth:`.oopinterface.QGFieldBase.compute_ncforce_from_heating_rate`.
+        See :py:meth:`.oopinterface.QGFieldNHN22.compute_ncforce_from_heating_rate`.
 
         Parameters
         ----------
-        heating_rate(xarray.DataArray): the diabatic heating output from reanalysis data on pressure levels that has unit K/s.
+        heating_rate : xarray.DataArray
+            The diabatic heating output from reanalysis data on pressure levels that has unit K/s.
 
         Returns
         -------


### PR DESCRIPTION
A bit of formatting and fixing a reference to `compute_ncforce_from_heating_rate` which is only available on `QGFieldNHN22`.