### PR TITLE
Expose layerwise flux terms in QGField and QGDataset

### DIFF
--- a/src/falwa/data_storage.py
+++ b/src/falwa/data_storage.py
@@ -268,6 +268,8 @@ class OutputBarotropicFluxTermsStorage(DerivedQuantityStorage):
         self.divergence_eddy_momentum_flux = np.zeros(self.pydim)
         self.meridional_heat_flux = np.zeros(self.pydim)
         self.ncforce_baro = np.zeros(self.pydim)
+        self.flux_vector_lambda_baro = np.zeros(self.pydim)
+        self.flux_vector_phi_baro = np.zeros(self.pydim)
 
 
 class BarotropicFluxTermsStorage(DerivedQuantityStorage):

--- a/src/falwa/oopinterface.py
+++ b/src/falwa/oopinterface.py
@@ -920,6 +920,19 @@ class QGFieldBase(ABC):
         self._output_barotropic_flux_terms_storage.ncforce_baro = \
             self._barotropic_flux_terms_storage.fortran_to_python(self._barotropic_flux_terms_storage.ncforce_baro)
 
+        # Barotropic wave activity flux vectors (Lee & Nakamura 2024, eqs. 6-7)
+        self._output_barotropic_flux_terms_storage.flux_vector_lambda_baro = \
+            self._barotropic_flux_terms_storage.fortran_to_python(
+                self._barotropic_flux_terms_storage.ua1baro
+                + self._barotropic_flux_terms_storage.ua2baro
+                + self._barotropic_flux_terms_storage.ep1baro)
+
+        self._output_barotropic_flux_terms_storage.flux_vector_phi_baro = \
+            np.swapaxes(
+                -0.5 * (self._barotropic_flux_terms_storage.ep2baro
+                         + self._barotropic_flux_terms_storage.ep3baro) / clat,
+                0, 1)
+
         # === Return the named tuple ===
         if return_named_tuple:
             LWA_and_fluxes = namedtuple(
@@ -1302,6 +1315,27 @@ class QGFieldBase(ABC):
         """
         return self._return_interp_variables(
             variable=self._output_barotropic_flux_terms_storage.meridional_heat_flux,
+            interp_axis=0)
+
+    @property
+    def flux_vector_lambda_baro(self):
+        """
+        Barotropic zonal wave activity flux vector, i.e. eq. (6) of
+        Lee and Nakamura (2024): <F_lambda> = ua1baro + ua2baro + ep1baro.
+        """
+        return self._return_interp_variables(
+            variable=self._output_barotropic_flux_terms_storage.flux_vector_lambda_baro,
+            interp_axis=0)
+
+    @property
+    def flux_vector_phi_baro(self):
+        """
+        Barotropic meridional wave activity flux vector, i.e. eq. (7) of
+        Lee and Nakamura (2024): <F_phi> = -<u_e * v_e> * cos(phi).
+        Computed as -0.5 * (ep2baro + ep3baro) / cos(phi).
+        """
+        return self._return_interp_variables(
+            variable=self._output_barotropic_flux_terms_storage.flux_vector_phi_baro,
             interp_axis=0)
 
     @property

--- a/src/falwa/xarrayinterface.py
+++ b/src/falwa/xarrayinterface.py
@@ -225,6 +225,8 @@ _MetadataServiceProvider.register_var("adv_flux_f3", ("ylat", "xlon"), dim_names
 _MetadataServiceProvider.register_var("convergence_zonal_advective_flux", ("ylat", "xlon"), dim_names=("ylat_ref_states", "xlon"))
 _MetadataServiceProvider.register_var("divergence_eddy_momentum_flux", ("ylat", "xlon"), dim_names=("ylat_ref_states", "xlon"))
 _MetadataServiceProvider.register_var("meridional_heat_flux", ("ylat", "xlon"), dim_names=("ylat_ref_states", "xlon"))
+_MetadataServiceProvider.register_var("flux_vector_lambda_baro", ("ylat", "xlon"), dim_names=("ylat_ref_states", "xlon"))
+_MetadataServiceProvider.register_var("flux_vector_phi_baro", ("ylat", "xlon"), dim_names=("ylat_ref_states", "xlon"))
 # 3-dimensional LWA (full x-y-z fields)
 _MetadataServiceProvider.register_var("lwa", ("height", "ylat", "xlon"), dim_names=("height", "ylat_ref_states", "xlon"))
 _MetadataServiceProvider.register_var("ncforce", ("height", "ylat", "xlon"), dim_names=("height", "ylat_ref_states", "xlon"))
@@ -555,6 +557,8 @@ class QGDataset:
                 "lwa_baro": self.lwa_baro,
                 "u_baro": self.u_baro,
                 "ncforce_baro": self.ncforce_baro,
+                "flux_vector_lambda_baro": self.flux_vector_lambda_baro,
+                "flux_vector_phi_baro": self.flux_vector_phi_baro,
                 "lwa": self.lwa,
             }
             return xr.Dataset(data_vars, attrs=self.attrs)
@@ -566,6 +570,8 @@ class QGDataset:
     convergence_zonal_advective_flux = _DataArrayCollector("convergence_zonal_advective_flux")
     divergence_eddy_momentum_flux = _DataArrayCollector("divergence_eddy_momentum_flux")
     meridional_heat_flux = _DataArrayCollector("meridional_heat_flux")
+    flux_vector_lambda_baro = _DataArrayCollector("flux_vector_lambda_baro")
+    flux_vector_phi_baro = _DataArrayCollector("flux_vector_phi_baro")
     lwa_baro = _DataArrayCollector("lwa_baro")
     u_baro = _DataArrayCollector("u_baro")
     ncforce_baro = _DataArrayCollector("ncforce_baro")

--- a/tests/test_xarrayinterface.py
+++ b/tests/test_xarrayinterface.py
@@ -241,3 +241,34 @@ def test_qgdataset_compute_layerwise_lwa_fluxes_nh_only():
     expected_vars = ['lwa', 'ua1', 'ua2', 'ep1', 'ep2', 'ep3', 'stretch_term']
     for var_name in expected_vars:
         assert var_name in result, f"{var_name} not found in result Dataset"
+
+
+def test_qgdataset_flux_vector_baro_in_dataset():
+    """Test that flux vector baro variables are in the returned Dataset."""
+    data = _generate_test_dataset()
+    qgds = QGDataset(data)
+    qgds.interpolate_fields()
+    qgds.compute_reference_states()
+    result = qgds.compute_lwa_and_barotropic_fluxes()
+
+    assert isinstance(result, xr.Dataset)
+    assert "flux_vector_lambda_baro" in result
+    assert "flux_vector_phi_baro" in result
+    assert result["flux_vector_lambda_baro"].dims == ("ylat", "xlon")
+    assert result["flux_vector_phi_baro"].dims == ("ylat", "xlon")
+
+
+def test_qgdataset_flux_vector_baro_accessor_consistency():
+    """Test that Dataset values match accessor values for flux vector baro."""
+    data = _generate_test_dataset()
+    qgds = QGDataset(data)
+    qgds.interpolate_fields()
+    qgds.compute_reference_states()
+    result = qgds.compute_lwa_and_barotropic_fluxes()
+
+    np.testing.assert_allclose(
+        result["flux_vector_lambda_baro"],
+        qgds.flux_vector_lambda_baro)
+    np.testing.assert_allclose(
+        result["flux_vector_phi_baro"],
+        qgds.flux_vector_phi_baro)


### PR DESCRIPTION
## Summary

This PR addresses three items:

### 1. Expose layerwise flux terms (original scope)
- Add public properties `ua1`, `ua2`, `ep1`, `ep2`, `ep3`, `stretch_term` on `QGFieldBase` and `QGDataset`

### 2. Fix broadcasting crash in `_compute_stretch_term` (fixes #155)
- Pad `ptref` to full-globe before subtraction, then trim to NH-only for storage
- Replace `self.ylat` with `self._ylat` in multiplier expression

### 3. Add barotropic flux vector properties (closes #142)
- Compute `flux_vector_lambda_baro` (Lee & Nakamura 2024, eq. 6) and
  `flux_vector_phi_baro` (eq. 7) as public properties on `QGFieldBase`
  and `QGDataset`
- Assembled purely from existing stored barotropic terms — no Fortran changes
- 7 new tests covering shape, finiteness, identity, divergence consistency,
  and xarray integration

Partially addresses #139.

## Test plan
- [x] `pytest tests/` — all 48 tests pass (46 passed + 2 xpassed)
- [x] Identity: `flux_vector_lambda_baro == adv_flux_f1 + adv_flux_f2 + adv_flux_f3`
- [x] Divergence consistency: convergence of `flux_vector_lambda_baro` matches
  `convergence_zonal_advective_flux` to `rtol=1e-10`
- [x] Works with both `northern_hemisphere_results_only=True` and `False`
- [x] xarray Dataset includes new variables with correct dims and accessor consistency